### PR TITLE
Enable RBAC authentication with fixed postgres-credentials secret

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,8 +7,9 @@ export POSTGRES_HOST="YOUR-POSTGRES-HOST.postgres.database.azure.com"
 export POSTGRES_USERNAME="YOUR-USERNAME"
 export POSTGRES_PASSWORD="YOUR-PASSWORD"
 
-# Materialize Authentication
-export MATERIALIZE_ADMIN_PASSWORD="YOUR-ADMIN-PASSWORD"
+# Materialize Authentication (Required for RBAC)
+# Use a strong password - this will be the admin user password
+export MATERIALIZE_ADMIN_PASSWORD="YOUR-SECURE-ADMIN-PASSWORD"
 
 # Azure Blob Storage Configuration  
 export AZURE_STORAGE_ACCOUNT="YOUR-STORAGE-ACCOUNT"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # Environment files with sensitive data
 .env
 
+# License key - contains sensitive data
+.license
+
 # Temporary files
 *.tmp
 *.swp

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ az aks get-credentials \
 
 3. **Access Materialize**:
    - Console: `http://<CONSOLE-IP>:8080`
-   - SQL: `psql "postgresql://materialize@<SQL-IP>:6875/materialize"`
+   - SQL (with RBAC): `psql "postgresql://materialize:${MATERIALIZE_ADMIN_PASSWORD}@<SQL-IP>:6875/materialize"`
 
 ## Configuration
 
@@ -153,6 +153,81 @@ az storage account generate-sas \
   --permissions rwdlacup \
   --expiry 2026-12-31 \
   --https-only
+```
+
+## RBAC Authentication
+
+This deployment enables Role-Based Access Control (RBAC) for secure access to Materialize.
+
+### Setup Authentication
+
+#### 1. Configure Admin Password
+```bash
+# Edit your .env file with a strong password
+export MATERIALIZE_ADMIN_PASSWORD="YourSecurePassword123!"
+source .env
+```
+
+#### 2. Deploy Authentication Secret
+```bash
+# Create the authentication secret with your password
+envsubst < apps/materialize/auth-secret.yaml | kubectl apply -f -
+```
+
+#### 3. Verify RBAC Configuration
+The Materialize environment is configured with:
+- `enableRbac: true` - RBAC enabled
+- `authenticatorKind: PasswordBased` - Password authentication  
+- `usersSecretName: materialize-users` - References the auth secret
+
+### Connecting with Authentication
+
+#### Via Port-Forward
+```bash
+kubectl port-forward -n materialize-system svc/mzmpl79if4kx-environmentd 6875:6875 &
+psql "postgresql://materialize:${MATERIALIZE_ADMIN_PASSWORD}@localhost:6875/materialize"
+```
+
+#### Via Load Balancer
+```bash
+# Get the external IP
+kubectl get svc -n materialize-system materialize-sql-external
+
+# Connect with authentication
+psql "postgresql://materialize:${MATERIALIZE_ADMIN_PASSWORD}@<EXTERNAL-IP>:6875/materialize"
+```
+
+### User Management
+
+Once connected as admin, you can create additional users:
+```sql
+-- Create a new user
+CREATE ROLE analyst LOGIN PASSWORD 'analyst_password';
+
+-- Grant permissions
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO analyst;
+GRANT SELECT ON ALL MATERIALIZED VIEWS IN SCHEMA public TO analyst;
+
+-- Connect as the new user
+psql "postgresql://analyst:analyst_password@<host>:6875/materialize"
+```
+
+### Troubleshooting RBAC
+
+**Connection Refused**: Check PostgreSQL connection limits
+```bash
+# Increase max_connections if needed
+az postgres flexible-server parameter set \
+  --resource-group materialize-rg \
+  --server-name <postgres-server> \
+  --name max_connections \
+  --value 200
+```
+
+**Authentication Failed**: Verify secret deployment
+```bash
+# Check if secret exists and has correct values
+kubectl get secret materialize-users -n materialize-system -o yaml
 ```
 
 ## Components
@@ -194,14 +269,19 @@ az storage blob list --account-name <account> --container-name <container>
 
 ### 1. Verify Materialize Connection
 ```bash
-kubectl run test-materialize --image=postgres:15 --restart=Never --rm -- \
-  bash -c "psql 'postgresql://materialize@<SERVICE-IP>:6875/materialize' -c 'SELECT 1 as test;'"
+# Get admin password from environment
+source .env
+
+# Test connection with authentication
+kubectl run test-materialize --image=postgres:15 --restart=Never --rm -it -- \
+  bash -c "psql 'postgresql://materialize:${MATERIALIZE_ADMIN_PASSWORD}@<SERVICE-IP>:6875/materialize' -c 'SELECT 1 as test;'"
 ```
 
 ### 2. Create Test Data
 ```bash
-kubectl run test-materialize --image=postgres:15 --restart=Never --rm -- \
-  bash -c "psql 'postgresql://materialize@<SERVICE-IP>:6875/materialize' <<EOF
+# Create test data with authentication
+kubectl run test-materialize --image=postgres:15 --restart=Never --rm -it -- \
+  bash -c "psql 'postgresql://materialize:${MATERIALIZE_ADMIN_PASSWORD}@<SERVICE-IP>:6875/materialize' <<EOF
 CREATE TABLE test_data (id INT, name TEXT);
 INSERT INTO test_data VALUES (1, 'blob-test-data'), (2, 'azure-storage');
 SELECT * FROM test_data;

--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ envsubst < apps/materialize/auth-secret.yaml | kubectl apply -f -
 #### 3. Verify RBAC Configuration
 The Materialize environment is configured with:
 - `enableRbac: true` - RBAC enabled
-- `authenticatorKind: PasswordBased` - Password authentication  
-- `usersSecretName: materialize-users` - References the auth secret
+- `authenticatorKind: Password` - Password authentication
+- License key required for RBAC features
 
 ### Connecting with Authentication
 

--- a/apps/materialize/auth-secret.yaml
+++ b/apps/materialize/auth-secret.yaml
@@ -2,7 +2,7 @@
 # This template uses environment variable substitution for security
 # 
 # Required environment variables (set via: source .env):
-# - MATERIALIZE_ADMIN_PASSWORD: Admin user password
+# - MATERIALIZE_ADMIN_PASSWORD: Strong admin user password
 #
 # Deploy with: source .env && envsubst < auth-secret.yaml | kubectl apply -f -
 
@@ -13,5 +13,6 @@ metadata:
   namespace: materialize-system
 type: Opaque
 stringData:
-  # Admin user credentials - change from defaults!
-  admin-password: "${MATERIALIZE_ADMIN_PASSWORD:-ChangeThisPassword123!}"
+  # Admin user password for RBAC authentication
+  # This will be used to create the 'materialize' admin user
+  admin-password: "${MATERIALIZE_ADMIN_PASSWORD}"

--- a/apps/materialize/environment.yaml
+++ b/apps/materialize/environment.yaml
@@ -13,8 +13,10 @@ spec:
   # Set environment ID (new ID for fresh initialization with blob storage)
   environmentId: 7f615ba3-d3f4-4184-b846-099507c70364
   
-  # Enable RBAC and security features (temporarily disabled due to PostgreSQL connection limits)
-  enableRbac: false
-  authenticatorKind: None
+  # Enable RBAC and security features
+  # NOTE: Requires sufficient PostgreSQL connection limits (increase max_connections if needed)
+  enableRbac: true
+  authenticatorKind: PasswordBased
+  usersSecretName: materialize-users
   
   # Azure Blob Storage configured via SAS token in persist_backend_url

--- a/apps/materialize/environment.yaml
+++ b/apps/materialize/environment.yaml
@@ -14,6 +14,8 @@ spec:
   environmentId: 7f615ba3-d3f4-4184-b846-099507c70364
   
   # Enable RBAC and security features
+  # NOTE: RBAC requires a valid Materialize license key (included in postgres-credentials secret)
+  # NOTE: RBAC requires postgres-credentials secret to have actual values (FIXED)
   # NOTE: Requires sufficient PostgreSQL connection limits (increase max_connections if needed)
   enableRbac: true
   authenticatorKind: Password

--- a/apps/materialize/environment.yaml
+++ b/apps/materialize/environment.yaml
@@ -16,7 +16,6 @@ spec:
   # Enable RBAC and security features
   # NOTE: Requires sufficient PostgreSQL connection limits (increase max_connections if needed)
   enableRbac: true
-  authenticatorKind: PasswordBased
-  usersSecretName: materialize-users
+  authenticatorKind: Password
   
   # Azure Blob Storage configured via SAS token in persist_backend_url

--- a/scripts/enable-rbac.sh
+++ b/scripts/enable-rbac.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Enable RBAC authentication for Materialize
+# This script deploys the authentication secret and restarts Materialize
+
+set -e
+
+echo "🔐 Enabling RBAC Authentication for Materialize"
+echo "==============================================="
+
+# Check required environment variables
+if [[ -z "${MATERIALIZE_ADMIN_PASSWORD}" ]]; then
+    echo "❌ Error: MATERIALIZE_ADMIN_PASSWORD environment variable not set"
+    echo ""
+    echo "Please set a strong admin password in your .env file:"
+    echo "  export MATERIALIZE_ADMIN_PASSWORD=\"YourSecurePassword123!\""
+    echo ""
+    echo "Then source the file: source .env"
+    exit 1
+fi
+
+echo "📋 Configuration:"
+echo "  Admin Password: *** (${#MATERIALIZE_ADMIN_PASSWORD} characters)"
+echo ""
+
+# Deploy the authentication secret
+echo "🔑 Deploying authentication secret..."
+envsubst < apps/materialize/auth-secret.yaml | kubectl apply -f -
+
+# Check if secret was created successfully
+if kubectl get secret materialize-users -n materialize-system &>/dev/null; then
+    echo "✅ Authentication secret created successfully"
+else
+    echo "❌ Failed to create authentication secret"
+    exit 1
+fi
+
+echo ""
+echo "🚀 RBAC has been enabled in the Materialize configuration."
+echo "   The changes will take effect when Flux redeploys the environment."
+echo ""
+echo "📊 To connect to Materialize with authentication:"
+echo "   kubectl port-forward -n materialize-system svc/mzmpl79if4kx-environmentd 6875:6875 &"
+echo "   psql \"postgresql://materialize:\${MATERIALIZE_ADMIN_PASSWORD}@localhost:6875/materialize\""
+echo ""
+echo "⚠️  Note: If you encounter connection issues, you may need to increase"
+echo "   PostgreSQL max_connections parameter:"
+echo "   az postgres flexible-server parameter set \\"
+echo "     --resource-group materialize-rg \\"
+echo "     --server-name <your-postgres-server> \\"
+echo "     --name max_connections \\"
+echo "     --value 200"
+echo ""
+echo "✨ RBAC setup complete!"

--- a/scripts/setup-eventhubs-sources.sh
+++ b/scripts/setup-eventhubs-sources.sh
@@ -18,6 +18,13 @@ if [[ -z "${EVENTHUBS_NAMESPACE}" ]]; then
     exit 1
 fi
 
+if [[ -z "${MATERIALIZE_ADMIN_PASSWORD}" ]]; then
+    echo "❌ Error: MATERIALIZE_ADMIN_PASSWORD environment variable not set"
+    echo "Please source your .env file: source .env"
+    echo "Note: This is required for RBAC-enabled Materialize authentication"
+    exit 1
+fi
+
 echo "🔧 Setting up Event Hubs sources in Materialize..."
 echo "📡 Event Hubs Namespace: ${EVENTHUBS_NAMESPACE}"
 
@@ -29,7 +36,7 @@ sleep 3
 
 # Substitute environment variables and run SQL
 echo "📝 Creating Event Hubs connection and sources..."
-envsubst < scripts/setup-multi-topic-connection.sql | psql "postgresql://materialize@localhost:6875/materialize"
+envsubst < scripts/setup-multi-topic-connection.sql | psql "postgresql://materialize:${MATERIALIZE_ADMIN_PASSWORD}@localhost:6875/materialize"
 
 # Kill port-forward
 kill $FORWARD_PID
@@ -43,4 +50,4 @@ echo "  python3 scripts/send-more-updates.py"
 echo ""
 echo "📊 To query data:"
 echo "  kubectl port-forward -n materialize-system svc/mzmpl79if4kx-environmentd 6875:6875 &"
-echo "  psql \"postgresql://materialize@localhost:6875/materialize\""
+echo "  psql \"postgresql://materialize:\${MATERIALIZE_ADMIN_PASSWORD}@localhost:6875/materialize\""


### PR DESCRIPTION
## Summary
- Fixed postgres-credentials secret to contain actual connection values instead of template variables
- Re-enabled RBAC with `enableRbac: true` and `authenticatorKind: Password`
- Updated environment.yaml configuration
- This resolves DNS resolution issues that prevented RBAC from working

## Changes Made
- **Fixed postgres-credentials secret**: Replaced template variables with actual PostgreSQL connection details
- **Re-enabled RBAC**: Set `enableRbac: true` and `authenticatorKind: Password` in environment.yaml  
- **Added license key**: Included Materialize license in postgres-credentials secret for RBAC support
- **Updated admin password**: Added `MATERIALIZE_ADMIN_PASSWORD` to .env file

## Test Plan
- [x] Verified postgres-credentials secret contains actual values (not template variables)
- [x] Confirmed license key is included in secret
- [x] Updated environment configuration to enable RBAC
- [ ] Test authentication after merge and Flux sync
- [ ] Verify both environmentd pods are running successfully

🤖 Generated with [Claude Code](https://claude.ai/code)